### PR TITLE
Store thumbnails in the Freedesktop specified directory.

### DIFF
--- a/elokab-files-manager.pro
+++ b/elokab-files-manager.pro
@@ -45,6 +45,6 @@ linux-g++*: {
 
  INSTALLS +=    elokabConfig \
                 elokabData \
-                applicationsData
-#                elokablib
+                applicationsData \
+                elokablib
 

--- a/elokab-fm/defines.h
+++ b/elokab-fm/defines.h
@@ -19,8 +19,10 @@
 #define D_PDF_TYPE      "pdf"
 #define D_VIDEO_TYPE    "video"
 
-#define D_KEY_FILEPATH  "FILEPATH"
-#define D_KEY_DATETIME  "DATETIME"
+#define THUMB_LAST_MODIFIED QStringLiteral("Thumb::MTime")
+#define THUMB_URI           QStringLiteral("Thumb::URI")
+#define THUMB_MIMETYPE      QStringLiteral("Thumb::Mimetype")
+#define THUMB_SIZE          QStringLiteral("Thumb::Size")
 
 #define D_COL_NAME      0
 #define D_COL_SIZE      1

--- a/elokab-fm/itemdelegate.h
+++ b/elokab-fm/itemdelegate.h
@@ -19,9 +19,11 @@
 
 #ifndef ITEMDELEGATE_H
 #define ITEMDELEGATE_H
+#include "thumbnails.h"
+
 #include <QAbstractItemDelegate>
 #include <QStyledItemDelegate>
-
+#include <QPointer>
 #include <QFileInfo>
 
 
@@ -33,7 +35,7 @@ class ItemDelegate : public QStyledItemDelegate
 public:
 
     //!
-    explicit ItemDelegate(bool modern);
+    explicit ItemDelegate(bool modern, Thumbnails* thumbnails);
 
     //!
     QSize sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const;
@@ -84,12 +86,8 @@ private slots:
     //!   جلب الايقونة
     QIcon decoration(const QModelIndex &index) const;
 
-    //!   جلب ايقونة المصغرات
-    QIcon iconThumbnails(const QString &file,const QString &type=QString())const;
-
 private:
 
-    QMap<QString ,QIcon>  *imageCache ;
     QMap<QString ,QIcon>  *iconCache ;
     QMap<QString ,QIcon>  *deskCache;
 
@@ -104,7 +102,7 @@ private:
     bool  isTreeview;
     bool  isModernMode;
 
-
+    QPointer<Thumbnails> _thumbFactory;
 
 };
 

--- a/elokab-fm/mylistview.h
+++ b/elokab-fm/mylistview.h
@@ -20,6 +20,7 @@
 #ifndef MYLISTVIEW_H
 #define MYLISTVIEW_H
 #include "actions.h"
+
 #include <QListView>
 #include<QFileSystemModel>
 /**

--- a/elokab-fm/pagewidget.cpp
+++ b/elokab-fm/pagewidget.cpp
@@ -67,9 +67,9 @@ PageWidget::PageWidget(MyFileSystemModel *model,
     vLayoutList->setSpacing(6);
     vLayoutList->setContentsMargins(0,0,0,0);
 
-    mItemDelegate=new ItemDelegate(!mSettings->isClassicIcons());
+    mThumbnails=new Thumbnails;
 
-    mThumbnails=new Thumbnails ;
+    mItemDelegate=new ItemDelegate(!mSettings->isClassicIcons(), mThumbnails);
 
     listView = new MyListView(myModel,mActions,pageList);
     listView->setItemDelegate(mItemDelegate);

--- a/elokab-fm/thumbnails.h
+++ b/elokab-fm/thumbnails.h
@@ -13,7 +13,7 @@ class Thread : public QThread
 public:
     Thread(){}
 
-    void setFile(const QFileInfo &info,const QString &type){mInfo=info;mType=type;}
+    void setFile(const QFileInfo &info,const QString &type);
     QString curentPath(){return mInfo.filePath();}
 
 signals:
@@ -28,10 +28,9 @@ private:
     QFileInfo   mInfo;
     QString     mType;
 
-
-    void createImageThumbnail();
-    void createPdfThumbnail();
-    void createVideoThumbnail();
+    void createImageThumbnail(const QString &filePath, QImage &image);
+    void createPdfThumbnailGS(const QString& filePath, QImage &image);
+    void createVideoThumbnail(const QString& filePath, QImage &image);
     QMap<QString,QString> videoInfo();
 };
 
@@ -43,11 +42,22 @@ public:
     explicit Thumbnails(QObject *parent = nullptr);
     //!
    ~Thumbnails();
+
+    enum class Size {
+        Normal,
+        Large,
+        XLarge,
+        XXLarge,
+        Fail
+    };
+
+    QIcon getThumbnail(const QFileInfo& fi, Size size = Size::Normal);
+
 signals:
     void updateThumbnail(const QString &path);
 
 public slots:
-    void addFileName(const QFileInfo &info, const QString &type);
+    void addFileName(const QFileInfo &info);
     void directoryChanged(const QString &path);
 
 private slots:
@@ -67,8 +77,6 @@ private:
     bool      canReadVideo;
 
     QMap<QString,QString>myMap;
-
-
 };
 
 #endif // THUMBNAILS_H

--- a/library/mimIcon/edir.cpp
+++ b/library/mimIcon/edir.cpp
@@ -139,12 +139,34 @@ QString Edir::applicationsHomeDir()
 //_________________________________________________________________
 QString Edir::thumbnaileCachDir()
 {
-       QString location=cachDir();
-       location+="/thumbnails";
-       QDir dir(location);
-       if(!dir.exists())
-           dir.mkpath(".");
-       return location;
+    QString cacheDir;
+
+    // Follow the FreeDesktop Spec
+    const QByteArray arr = qgetenv("XDG_CACHE_HOME");
+    if (!arr.isEmpty()) {
+        QFileInfo fi(arr);
+        if (fi.exists() && fi.isReadable()) {
+            cacheDir = fi.absoluteFilePath();
+            cacheDir += QStringLiteral("/thumbnails/");
+        }
+    }
+
+    if (cacheDir.isEmpty()) {
+        cacheDir = QDir::homePath();
+        cacheDir += QStringLiteral("/.cache/thumbnails/");
+    }
+
+    // check if
+    if (!cacheDir.isEmpty()) {
+        QDir dir(cacheDir);
+        if(!dir.exists())
+            dir.mkpath(".");
+        // FIXME: check for all the other sizes
+        QDir dirNormal(cacheDir+"normal/");
+        if(!dirNormal.exists())
+            dirNormal.mkpath(".");
+    }
+    return cacheDir;
 }
 
 //_________________________________________________________________

--- a/library/mimIcon/mimIcon.pro
+++ b/library/mimIcon/mimIcon.pro
@@ -1,6 +1,7 @@
 QT       += core gui dbus
 greaterThan(QT_MAJOR_VERSION, 4): QT += widgets gui core
-CONFIG      +=  plugin release
+CONFIG      += plugin
+CONFIG      += debug
 TARGET      = $$qtLibraryTarget(elokabmimicon)
 DESTDIR = ../../usr/lib
 


### PR DESCRIPTION
In
https://specifications.freedesktop.org/thumbnail-spec/thumbnail-spec-latest.html#INTRODUCTION
is a specification of how thumbnails should be stored to be freedesktop
compliant.

This patch saves the thumbnails according to that.

In addition a couple of improvements to thumb generation of
images and PDFs. PDF thumbs are generated via ghostscript.
Video is almost unchanged but untested.